### PR TITLE
Name Linux binary by platform and architecture

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Test
       run: |
         tox -e ${{ matrix.config[1] }}
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@v8
       with:
         name: dist-${{ matrix.config[1] }}-${{ matrix.config[2] }}  # dist-exe-windows-latest
         path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -211,5 +211,5 @@ jobs:
           allowUpdates: true
           body: "For a list of changes, please refer to the [Changelog](https://github.com/niccokunzmann/ics-query#changelog)."
           generateReleaseNotes: false
-          artifacts: "dist/dist-exe-windows-latest/ics-query.exe,dist/dist-exe-ubuntu-latest/ics-query"
+          artifacts: "dist/dist-exe-windows-latest/ics-query.exe,dist/dist-exe-ubuntu-latest/ics-query-linux-x86_64"
           tag: ${{ needs.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pipx ensurepath
 ### Download binaries
 
 For **Windows**, you can download `ics-query.exe` from our [Releases].  
-For **Linux**, you can download `ics-query` from our [Releases].  
+For **Linux** (x86_64), you can download `ics-query-linux-x86_64` from our [Releases].  
 
 ### Install with Homebrew on MacOS
 
@@ -488,6 +488,10 @@ To add a new Python version, update these files:
 We automatically release the versions that only update dependencies.
 If the version you installed does not show up here, only the dependencies
 have been updated.
+
+- v0.5.8
+
+  - Name Linux binary by platform and architecture (e.g. `ics-query-linux-x86_64`). See [Issue 70](https://github.com/pycalendar/ics-query/issues/70).
 
 - v0.5.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,4 @@ deps =
 commands =
     pyinstaller ics-query.py --onefile --paths "{env_site_packages_dir}" --recursive-copy-metadata ics-query
     python -c "import subprocess,sys,sysconfig; sys.exit(subprocess.run([sys.executable,'-m','pytest','--binary','dist/ics-query'+(sysconfig.get_config_var('EXE') or '')]).returncode)"
+    python -c "import os,platform,sysconfig; ext=sysconfig.get_config_var('EXE') or ''; src='dist/ics-query'+ext; dst='dist/ics-query-linux-'+platform.machine() if not ext else src; os.rename(src,dst) if src!=dst else None"


### PR DESCRIPTION
- Name Linux binary by platform and architecture (e.g. `ics-query-linux-x86_64`)
- Fix `upload-artifact@v7` → `@v8` to restore binaries on release page

Contributes to #70
