### PR TITLE
Fix upload-artifact and download-artifact back to @v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Test
       run: |
         tox -e ${{ matrix.config[1] }}
-    - uses: actions/upload-artifact@v8
+    - uses: actions/upload-artifact@v7
       with:
         name: dist-${{ matrix.config[1] }}-${{ matrix.config[2] }}  # dist-exe-windows-latest
         path: dist
@@ -196,7 +196,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v7
         with:
           pattern: dist-*
           path: dist


### PR DESCRIPTION
PR #81 accidentally changed `upload-artifact` from `@v7` to `@v8`. `@v8` does not exist, which broke the entire release pipeline.

`@v7` is the correct latest version (as Renovate set it in PR #77). This reverts that mistake.
Contributes #70